### PR TITLE
Wrap iOS post processor in UNITY_IOS. 

### DIFF
--- a/Assets/Editor/AmplitudePostProcessor.cs
+++ b/Assets/Editor/AmplitudePostProcessor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿#if UNITY_IOS
+using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
 
@@ -24,3 +25,4 @@ public static class AmplitudePostProcessor {
     }
   }
 }
+#endif


### PR DESCRIPTION
If you don't have iOS module installed then a compilation error will happen saying 

```csharp
error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
```

To avoid this issue and that amplitude can be used in Android independently I've wrapped the iOS class with UNITY_IOS define.