### PR TITLE
Unity Package Manager

### DIFF
--- a/Assets/Editor/Editor.asmdef
+++ b/Assets/Editor/Editor.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "Editor",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Editor/Editor.asmdef.meta
+++ b/Assets/Editor/Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15b16957054fc456d8686df4a9470075
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SDK.asmdef
+++ b/Assets/SDK.asmdef
@@ -2,9 +2,7 @@
     "name": "SDK",
     "references": [],
     "includePlatforms": [],
-    "excludePlatforms": [
-        "XboxOne"
-    ],
+    "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],

--- a/Assets/SDK.asmdef
+++ b/Assets/SDK.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "SDK",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "XboxOne"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/SDK.asmdef.meta
+++ b/Assets/SDK.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c22016687ff334899a4aa5bda3c9ee82
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "com.amplitude.unityplugin",
+    "version": "2.1.0",
+    "displayName": "Amplitude Unity SDK",
+    "description": "A plugin to simplify the integration of Amplitude iOS and Android SDKs into your Unity project. This repository also contains a sample project with the Unity plugin integrated.",
+    "unity": "2019.4",
+    "unityRelease": "18f1",
+    "dependencies": {
+
+    },
+    "keywords": [
+        "Amplitude"
+    ],
+    "author": {
+        "name": "Amplitude",
+        "email": "contact@amplitude.com",
+        "url": "https://github.com/amplitude/unity-plugin/"
+    }
+}

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64839cfeb32114742b2ee62000271e04
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This allows users to download the Amplitude Unity SDK through the GitHub url:
`https://github.com/amplitude/unity-plugin.git?path=/Assets`

The version number may also be specified. 
`https://github.com/amplitude/unity-plugin.git?path=/Assets#v2.0.0`